### PR TITLE
feat:챌린지 완료 시 alert 표시

### DIFF
--- a/Blim/Sources/Features/Main/MainView.swift
+++ b/Blim/Sources/Features/Main/MainView.swift
@@ -21,11 +21,23 @@ struct MainView: View {
             .onAppear {
                 viewModel.syncChallengeState(from: challenges, context: context)
             }
+            .onChange(of: challenges) { newChallenges in
+                viewModel.syncChallengeState(from: newChallenges, context: context)
+            }
+            
             .sheet(isPresented: $showSheet) {
                 let newVM = NewChallengeViewModel()
                 NewChallengeView(viewModel: newVM)
                     .presentationDetents([.medium, .large])
             }
+            .alert("🎉 챌린지 완료!", isPresented: $viewModel.shouldShowCompletionPopup) {
+                Button("새로운 챌린지 시작하기") {
+                    showSheet = true
+                }
+            } message: {
+                Text("정말 멋져요! 챌린지를 끝냈어요.\n새로운 도전을 시작해볼까요?")
+            }
+
         }
     }
 

--- a/Blim/Sources/Features/Main/MainViewModel.swift
+++ b/Blim/Sources/Features/Main/MainViewModel.swift
@@ -11,13 +11,15 @@ import SwiftData
 final class MainViewModel: ObservableObject {
     @Published var activeChallenge: Challenge? = nil
     @Published var hasNoChallenge: Bool = true
+    @Published var shouldShowCompletionPopup: Bool = false
 
     func syncChallengeState(from challenges: [Challenge], context: ModelContext) {
-        // 진행 가능한 챌린지만 남기고 나머지 삭제
         var hasValid = false
 
         for challenge in challenges {
             if challenge.endDate < Date() {
+                // ✅ 챌린지 종료 감지
+                shouldShowCompletionPopup = true
                 context.delete(challenge)
             } else {
                 activeChallenge = challenge


### PR DESCRIPTION
### 주요 변경사항

- 챌린지의 `endDate`가 현재 날짜를 지난 경우, 챌린지를 삭제하기 전에 축하 메시지(Alert)를 팝업으로 표시
- 사용자에게 챌린지 완료를 감성적으로 안내하고, 자연스럽게 다음 챌린지를 시작하도록 유도
- 완료 알림은 `MainViewModel`에서 `@Published var shouldShowCompletionPopup`으로 상태 관리
- `MainView`에서는 `.alert(...)`을 통해 UI 레이어에서 축하 메시지를 출력