### PR TITLE
feat: 챌린지 삭제 기능

### DIFF
--- a/Blim/Sources/Features/ChallengeCardView.swift
+++ b/Blim/Sources/Features/ChallengeCardView.swift
@@ -10,27 +10,81 @@ import SwiftUI
 
 struct ChallengeCardView: View {
     let challenge: Challenge
+    @Environment(\.modelContext) private var context
+    var onDelete: (() -> Void)?   // ✅ 삭제 핸들러
+    @State private var taskText: String = ""
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("📌 나의 챌린지")
-                .font(.caption)
-                .foregroundStyle(.gray)
+        VStack(spacing: 16) {
+            // ✅ 상단 챌린지 카드
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("📌 나의 챌린지")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
 
-            Text(challenge.title)
-                .font(.title2.bold())
+                    Spacer()
 
-            Text("\(challenge.startDate.formatted()) ~ \(challenge.endDate.formatted())")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
+                    // ✅ 삭제 버튼만 표시
+                    Button {
+                        onDelete?()
+                    } label: {
+                        Image(systemName: "trash")
+                            .foregroundColor(.red)
+                    }
+                }
+
+                Text(challenge.title)
+                    .font(.title2.bold())
+
+                Text("\(challenge.startDate.formatted()) ~ \(challenge.endDate.formatted())")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(.thinMaterial)
+            .cornerRadius(16)
+
+            Spacer()
+
+            // ✅ 하단 Task 입력 (Underline 스타일)
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField("오늘의 계획을 입력하세요", text: $taskText)
+                        .font(.body)
+                        .padding(.vertical, 8)
+                        .overlay(
+                            Rectangle()
+                                .frame(height: 1)
+                                .foregroundColor(.gray),
+                            alignment: .bottom
+                        )
+                }
+
+                Button {
+                    addTask()
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(.title2)
+                }
+                .disabled(taskText.isEmpty)
+            }
+            .padding(.horizontal)
+
+            Spacer()
         }
         .padding()
-        .frame(maxWidth: .infinity)
-        .background(.thinMaterial)
-        .cornerRadius(16)
-        .shadow(radius: 4)
+    }
+
+    private func addTask() {
+        let newTask = Task(title: taskText, challenge: challenge)
+        context.insert(newTask)
+        try? context.save()
+        taskText = ""
     }
 }
+
 
 #Preview {
     ChallengeCardView(

--- a/Blim/Sources/Features/Main/MainView.swift
+++ b/Blim/Sources/Features/Main/MainView.swift
@@ -6,12 +6,27 @@ struct MainView: View {
     @Environment(\.modelContext) private var context
     @StateObject private var viewModel = MainViewModel()
     @State private var showSheet = false
-
+    @State private var showDeleteAlert = false
+    @State private var challengeToDelete: Challenge?
+    
     var body: some View {
         NavigationView {
             VStack(spacing: 24) {
                 if let challenge = viewModel.activeChallenge {
-                    ChallengeCardView(challenge: challenge)
+                    ChallengeCardView(challenge: challenge) {
+                        challengeToDelete = challenge
+                        showDeleteAlert = true
+                    }
+                    .alert("🧹 챌린지를 삭제할까요?", isPresented: $showDeleteAlert) {
+                        Button("삭제", role: .destructive) {
+                            if let challenge = challengeToDelete {
+                                viewModel.deleteChallenge(challenge, context: context)
+                            }
+                        }
+                        Button("취소", role: .cancel) { }
+                    } message: {
+                        Text("너무 어려운 도전이었나요?\n괜찮아요, 더 간단한 목표를 지정해봐요!")
+                    }
                 } else if viewModel.hasNoChallenge {
                     emptyState
                 }
@@ -37,16 +52,16 @@ struct MainView: View {
             } message: {
                 Text("정말 멋져요! 챌린지를 끝냈어요.\n새로운 도전을 시작해볼까요?")
             }
-
+            
         }
     }
-
+    
     private var emptyState: some View {
         VStack(spacing: 16) {
             Text("계획하신 챌린지가 없어요!\n챌린지를 시작해보아요!")
                 .multilineTextAlignment(.center)
                 .font(.headline)
-
+            
             Button("챌린지 생성") {
                 showSheet = true
             }

--- a/Blim/Sources/Features/Main/MainViewModel.swift
+++ b/Blim/Sources/Features/Main/MainViewModel.swift
@@ -30,4 +30,12 @@ final class MainViewModel: ObservableObject {
         try? context.save()
         hasNoChallenge = !hasValid
     }
+    
+    func deleteChallenge(_ challenge: Challenge, context: ModelContext) {
+        context.delete(challenge)
+        try? context.save()
+        activeChallenge = nil
+        hasNoChallenge = true
+    }
+
 }


### PR DESCRIPTION
### 작업 내역

- Challenge 모델을 SwiftData 기반으로 삭제 처리할 수 있는 기능 구현
- ChallengeRepository에 `deleteChallenge(_:)` 메서드 추가
- ViewModel에서 해당 메서드를 호출해 삭제 동작 수행
- 삭제 완료 후 Challenge 리스트 자동 리프레시
- 삭제 시 Alert로 사용자에게 삭제 여부 재확인 처리